### PR TITLE
Add missing dependency on OpenCV

### DIFF
--- a/src/iKartPathPlanner/CMakeLists.txt
+++ b/src/iKartPathPlanner/CMakeLists.txt
@@ -13,8 +13,8 @@ file(GLOB folder_header *.h)
 source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
-include_directories(${YARP_INCLUDE_DIRS} ${ICUB_INCLUDE_DIRS})
+include_directories(${YARP_INCLUDE_DIRS} ${ICUB_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES} ${ICUB_LIBRARIES})
+target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES} ${ICUB_LIBRARIES} ${OpenCV_LIBS})
 install(TARGETS ${PROJECTNAME} DESTINATION bin)
 


### PR DESCRIPTION
Building fails without the dependency on OpenCV. Don't ask me why it fails now and not earlier ;).
