### PR TITLE
Compatibility with ROS indigo, fixing warnings

### DIFF
--- a/app/iKart/conf/ikart_calib.xml
+++ b/app/iKart/conf/ikart_calib.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<devices>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
+<devices robot="ikart" build="1">
     <device name="ikart_calibrator" type="parametricCalibrator">
     <params file="general.xml" />
                 

--- a/app/iKart/conf/ikart_main.xml
+++ b/app/iKart/conf/ikart_main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-
-<robot name="ikart">
+<!DOCTYPE robot PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
+<robot name="ikart" build="1" portprefix="ikart">
     <devices file="ikart_mc.xml" />
     <devices file="ikart_mc_wrapper.xml" />
     <devices file="ikart_calib.xml" /> 

--- a/app/iKart/conf/ikart_mc.xml
+++ b/app/iKart/conf/ikart_mc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<devices>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
+<devices robot="ikart" build="1">
     <device name="ikart_mc" type="canmotioncontrol">
     <params file="general.xml" />
 

--- a/app/iKart/conf/ikart_mc_wrapper.xml
+++ b/app/iKart/conf/ikart_mc_wrapper.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<devices>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD robotInterface 1.0//EN" "http://www.icub.org/DTD/robotInterfaceV1.0.dtd">
+<devices robot="ikart" build="1">
   <device name="ikart_mc_wrapper" type="controlboardwrapper2">
       <paramlist name="networks">
       <elem name="wheels">  0 2 0 2 </elem>
@@ -9,7 +10,6 @@
       <param name="name">   /ikart/wheels </param>
       <param name="ports">  wheels        </param>
       <param name="joints"> 3             </param>
-
 
       <action phase="startup" level="5" type="attach">
       <paramlist name="networks">

--- a/app/iKart/ikart_boot/ikart_start.sh
+++ b/app/iKart/ikart_boot/ikart_start.sh
@@ -9,7 +9,7 @@ if [ $ret1 -eq 101 ]; then
     #sudo -u icub -i icub-cluster-server.sh start yarpserver3 &
     sleep 2
     sudo -u icub -i joystickCtrl --context joystickCtrl --from ikart.ini --silent --force_configuration &
-    sudo -u icub -i robotInterface --context iKart &
+    sudo -u icub -i robotInterface --context iKart --config ikart_main.xml &
     sudo -u icub -i iKartCtrl --context iKart --no_compass --joystick_connect &
 elif [ $ret1 -eq 0 ]; then
     echo "No joystick boot requested" 

--- a/app/iKart/scripts/iKartROS.xml.template
+++ b/app/iKart/scripts/iKartROS.xml.template
@@ -1,0 +1,66 @@
+<application>
+<name>iKart ROS mapping</name>
+
+<module>
+   <name>roscore</name>
+   <parameters></parameters>
+   <node>ikart</node>
+   <tag>roscoreTag</tag>
+</module>
+
+<module>
+   <name>rosrun</name>
+   <parameters>iKartRosBridge iKartRosBridge</parameters>
+   <node>ikart</node>
+   <tag>rosBridgeTag</tag>
+</module>
+
+<module>
+   <name>roslaunch</name>
+   <parameters>iKartRosBridge ikart_build_map.launch</parameters>
+   <node>ikart</node>
+   <tag>rosBuildMapTag</tag>
+</module>
+
+<module>
+   <name>rosrun</name>
+   <parameters>map_server map_saver</parameters>
+   <node>ikart</node>
+   <tag>rosSaveMapTag</tag>
+</module>
+
+<module>
+   <name>rosrun</name>
+   <parameters>map_server map_server map.yaml</parameters>
+   <node>ikart</node>
+   <tag>rosLoadMapTag</tag>
+</module>
+
+<module>
+   <name>roslaunch</name>
+   <parameters>iKartRosBridge ikart_localize.launch</parameters>
+   <node>ikart</node>
+   <tag>rosLocalizeTag</tag>
+</module>
+
+<module>
+   <name>roslaunch</name>
+   <parameters>iKartRosBridge ikart_navigate2.launch</parameters>
+   <node>ikart</node>
+   <tag>rosNavigateTag</tag>
+</module>
+
+<module>
+   <name>rviz</name>
+   <parameters></parameters>
+   <node>icuboracle</node>
+   <tag>rvizTag</tag>
+</module>
+
+<connection>
+  <from>/ikart_ros_bridge/command:o</from>
+  <to>/ikart/control:i</to>
+  <protocol>tcp</protocol>
+</connection>
+
+</application>

--- a/src/iKartRosBridge/config/base_local_planner_params.yaml
+++ b/src/iKartRosBridge/config/base_local_planner_params.yaml
@@ -1,12 +1,12 @@
 controller_frequency: 10.0
 TrajectoryPlannerROS:
-  max_vel_x: 0.15
+  max_vel_x: 0.075
   min_vel_x: 0.025
-  max_rotational_vel: 0.1
-  min_in_place_rotational_vel: 0.05
-  acc_lim_th: 0.12
-  acc_lim_x: 0.50
-  acc_lim_y: 0.50
+  max_rotational_vel: 0.05
+  min_in_place_rotational_vel: 0.025
+  acc_lim_theta: 0.06
+  acc_lim_x: 0.25
+  acc_lim_y: 0.25
 
   holonomic_robot: false
   yaw_goal_tolerance: 0.3

--- a/src/iKartRosBridge/launch/ikart_build_map.launch
+++ b/src/iKartRosBridge/launch/ikart_build_map.launch
@@ -6,8 +6,5 @@
   <param name="temporalUpdate" value="0.5" />
   </node>
 
-  <!-- for visualization -->
-  <node pkg="rviz" type="rviz" name="rviz" args="-d $(find iKartRosBridge)/display/rviz_build_map.vcg"/>
-
 </launch>
 


### PR DESCRIPTION
Hi,
this PR addresses a couple of issues with the ikart software package.
1) The config files are outdated and give warnings when running robotInterface
2) When using the ROS navigation stack, the velocity settings were too high
3) Addition of a new template file to start the ROS navigation stack

One issue which still needs to be resolved is updating https://github.com/robotology/ikart/blob/master/app/iKart/scripts/iKart.xml.template - this has still iCubInterface in there etc. - I'll leave that up to you guys. I have a working version for our robot, however it is not generic enough to be in this PR.

I would appreciate if you could merge this PR :+1: .

Best,
Tobias
