### PR TITLE
Explicitly set the VELOCITY_CONTROL::velocityControlImplementationType parameter to ensure compatibility with gazebo-yarp-plugins 4

### DIFF
--- a/gazebo/ikart/conf/gazebo_ikart_mobile_base.ini
+++ b/gazebo/ikart/conf/gazebo_ikart_mobile_base.ini
@@ -37,6 +37,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/gazebo/ikart_wheels_friction/conf/gazebo_ikart_mobile_base.ini
+++ b/gazebo/ikart_wheels_friction/conf/gazebo_ikart_mobile_base.ini
@@ -37,6 +37,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           0.2   0.2   0.2


### PR DESCRIPTION
In https://github.com/robotology/gazebo-yarp-plugins/pull/514 (changelog entry: https://github.com/robotology/gazebo-yarp-plugins/blob/master/CHANGELOG.md#351---2020-10-05), the `VELOCITY_CONTROL::velocityControlImplementationType` parameter was added to the `gazebo_yarp_control` plugin to permit the users to switch between velocity control implemented between the `direct_velocity_pid` implementation (the default used until then) and the `integrator_and_position_pid` implementation (that is not a velocity-based PID, but rather an integrator in series with the classical position control).

The parameter was added as optional in gazebo-yarp-plugins 3.5.1, but to avoid confusion it will be make compulsory in gazebo-yarp-plugins 4 . To avoid creating runtime error in gazebo-yarp-plugins 4, this PR adds the parameter to the configuration files in this repo, using the default value `direct_velocity_pid`. However, mantainers may want to switch to use integrator_and_position_pid`  it if makes more sense in the future.

Related issues: https://github.com/robotology/gazebo-yarp-plugins/issues/577, https://github.com/robotology/gazebo-yarp-plugins/pull/578 .